### PR TITLE
[WIP] Simplify the build, use .syso rather than manual `go tool` invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ export RUSTFLAGS ?= -Ctarget-cpu=native
 TARGET           := $(shell GOOS=$(shell go env GOHOSTOS) GOARCH=$(shell go env GOHOSTARCH) \
                             go run target.go $(shell go env GOOS) $(shell go env GOARCH))
 
-edwards25519/edwards25519.a: edwards25519/rustgo.go edwards25519/rustgo.o edwards25519/libed25519_dalek_rustgo.o
-		go tool compile -N -l -o $@ -p main -pack edwards25519/rustgo.go
-		go tool pack r $@ edwards25519/rustgo.o edwards25519/libed25519_dalek_rustgo.o
+.PHONY: build
+build: edwards25519/libed25519_dalek_rustgo.syso
+		go build
 
-edwards25519/libed25519_dalek_rustgo.o: target/$(TARGET)/release/libed25519_dalek_rustgo.a
+edwards25519/libed25519_dalek_rustgo.syso: target/$(TARGET)/release/libed25519_dalek_rustgo.a
 ifeq ($(shell go env GOOS),darwin)
 		$(LD) -r -o $@ -arch x86_64 -u "_$(SYMBOL)" $^
 else
@@ -20,9 +20,6 @@ endif
 target/$(TARGET)/release/libed25519_dalek_rustgo.a: src/* Cargo.toml Cargo.lock
 		cargo build --release --target $(TARGET)
 
-edwards25519/rustgo.o: edwards25519/rustgo.s
-		go tool asm -I "$(shell go env GOROOT)/pkg/include" -o $@ $^
-
 .PHONY: install uninstall
 install: edwards25519/edwards25519.a
 		mkdir -p "$(INSTALL_PATH)"
@@ -30,6 +27,8 @@ install: edwards25519/edwards25519.a
 uninstall:
 		rm -f "$(INSTALL_PATH)/edwards25519.a"
 
-.PHONY: clean
-clean:
-		rm -rf edwards25519/*.[oa] target ed25519-dalek-rustgo
+.PHONY: clean clean-go
+clean: clean-go
+		rm -rf target
+clean-go:
+		rm -rf */*.[oa] */*.syso ed25519-dalek-rustgo

--- a/edwards25519/rustgo.go
+++ b/edwards25519/rustgo.go
@@ -1,5 +1,3 @@
-//go:binary-only-package
-
 // Package edwards25519 implements operations on an Edwards curve that is
 // isomorphic to curve25519.
 //
@@ -8,14 +6,6 @@
 //
 // You should not actually be using this.
 package edwards25519
-
-import _ "unsafe"
-
-//go:cgo_import_static scalar_base_mult
-//go:cgo_import_dynamic scalar_base_mult
-//go:linkname scalar_base_mult scalar_base_mult
-var scalar_base_mult uintptr
-var _scalar_base_mult = &scalar_base_mult
 
 // ScalarBaseMult multiplies the scalar in by the curve basepoint, and writes
 // the compressed Edwards representation of the resulting point to dst.

--- a/edwards25519/rustgo.s
+++ b/edwards25519/rustgo.s
@@ -6,9 +6,8 @@ TEXT ·ScalarBaseMult(SB), 0, $16384-16
 	ADDQ $16384, SP
 	ANDQ $~15, SP
 
-	MOVQ ·_scalar_base_mult(SB), AX
+	MOVQ scalar_base_mult(SB), AX
 	CALL AX
 
 	MOVQ BX, SP
 	RET
-


### PR DESCRIPTION
Go recently [restricted](https://github.com/golang/go/issues/23672) the ability to use `go:cgo_*` directives outside of cgo-generated code so the current build no longer works.

I've modified the build to use the [syso trick](https://github.com/golang/go/wiki/GcToolchainTricks) which greatly simplifies the tool invocations. Everything builds successfully and all the symbols are found (tested on Debian GNU/Linux buster) but I get a segfault as soon as I run the program.

So I guess `rustgo.s` needs to be updated, but my assembly hacking skills are lacking here. Since you've been through this process before, I thought you might be able to fix this up quicker on top of what I've already done.

For a start, changing `MOVQ scalar_base_mult(SB), AX \n CALL AX` to `CALL scalar_base_mult(SB)` results in a "simpler" segfault error but I have no idea if it's a "better" error.
